### PR TITLE
Add permission removal functionality to SafeKey contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,22 @@ A decentralized key management system built on the Stacks blockchain. This contr
 ## Features
 
 - Secure key ownership registration
-- Key transfer capabilities
+- Key transfer capabilities  
 - Access control management
+- Permission removal functionality
 - Key usage tracking
 - Role-based permissions
 
 ## Usage
 
-The contract provides functions for managing digital keys in a decentralized way. Key owners can register keys, set permissions, and transfer ownership while maintaining a transparent history of key usage.
+The contract provides functions for managing digital keys in a decentralized way. Key owners can:
+- Register new keys
+- Transfer key ownership
+- Add permissions for other users
+- Remove permissions from users
+- Track key usage history
+
+### New Features
+- Added ability to remove permissions from users
+- Added error handling for permission removal
+- Enhanced permission management capabilities

--- a/tests/safe_key_test.ts
+++ b/tests/safe_key_test.ts
@@ -86,5 +86,24 @@ Clarinet.test({
         
         block.receipts[1].result.expectOk().expectBool(true);
         block.receipts[2].result.expectOk().expectBool(true);
+
+        // Test permission removal
+        block = chain.mineBlock([
+            Tx.contractCall('safe-key', 'remove-permission', [
+                types.uint(1),
+                types.principal(wallet2.address)
+            ], wallet1.address)
+        ]);
+
+        block.receipts[0].result.expectOk().expectBool(true);
+
+        // Verify wallet2 can no longer use the key
+        block = chain.mineBlock([
+            Tx.contractCall('safe-key', 'use-key', [
+                types.uint(1)
+            ], wallet2.address)
+        ]);
+
+        block.receipts[0].result.expectErr().expectUint(100);
     }
 });


### PR DESCRIPTION
This PR adds the ability to remove permissions from users in the SafeKey contract. The enhancement includes:

- New `remove-permission` public function to revoke access from specific users
- Additional error constant `ERR-PERMISSION-NOT-FOUND` for better error handling
- Updated tests to verify permission removal functionality
- Updated documentation to reflect new features

The changes are backward compatible and enhance the contract's access control capabilities by allowing key owners to revoke permissions when needed. This is an important security feature that was missing from the original implementation.

Technical Details:
- Added new error constant ERR-PERMISSION-NOT-FOUND (u103)
- Implemented remove-permission function using list manipulation
- Added test cases to verify permission removal and subsequent access attempts
- Updated documentation to reflect new capabilities

The implementation maintains the existing security model where only key owners can modify permissions.